### PR TITLE
Simplified extension registration

### DIFF
--- a/modules/custom_operations/user_ie_extensions/ov_extension.cpp
+++ b/modules/custom_operations/user_ie_extensions/ov_extension.cpp
@@ -89,8 +89,7 @@
 #ifdef paged_attention
 #    include "paged_attention/paged_attention.hpp"
 #    define PAGED_ATTENTION_EXT \
-            std::make_shared<ov::OpExtension<TemplateExtension::PagedAttention>>(), \
-            std::make_shared<ov::frontend::OpExtension<TemplateExtension::PagedAttention>>(),
+            std::make_shared<ov::OpExtension<TemplateExtension::PagedAttention>>()
 #else
 #    define PAGED_ATTENTION_EXT
 #endif

--- a/modules/custom_operations/user_ie_extensions/paged_attention/paged_attention.hpp
+++ b/modules/custom_operations/user_ie_extensions/paged_attention/paged_attention.hpp
@@ -25,8 +25,8 @@ namespace TemplateExtension {
 
 class PagedAttention : public ov::op::Op {
 public:
-    OPENVINO_OP("PagedAttentionExtension", "extension");
-    OPENVINO_FRAMEWORK_MAP(pytorch, "vllm.model_executor.layers.attention.PagedAttention");
+    OPENVINO_OP("PagedAttentionExtension");
+    OPENVINO_FRAMEWORK_MAP(pytorch);
 
     PagedAttention() = default;
 


### PR DESCRIPTION
- No explicit registration of frontend::OpExtension (works with the lates slyalin/openvino/pytorch_module_extension branch)
- Removed unnecessary `extension` opset from OPENVINO_OP.